### PR TITLE
Fix/multiclass recall macro avg ignore index

### DIFF
--- a/src/torchmetrics/classification/precision_recall.py
+++ b/src/torchmetrics/classification/precision_recall.py
@@ -746,6 +746,7 @@ class MulticlassRecall(MulticlassStatScores):
             fn,
             average=self.average,
             multidim_average=self.multidim_average,
+            ignore_index = self.ignore_index,
             top_k=self.top_k,
             zero_division=self.zero_division,
         )

--- a/src/torchmetrics/classification/precision_recall.py
+++ b/src/torchmetrics/classification/precision_recall.py
@@ -746,7 +746,7 @@ class MulticlassRecall(MulticlassStatScores):
             fn,
             average=self.average,
             multidim_average=self.multidim_average,
-            ignore_index = self.ignore_index,
+            ignore_index=self.ignore_index,
             top_k=self.top_k,
             zero_division=self.zero_division,
         )

--- a/src/torchmetrics/functional/classification/precision_recall.py
+++ b/src/torchmetrics/functional/classification/precision_recall.py
@@ -43,6 +43,7 @@ def _precision_recall_reduce(
     average: Optional[Literal["binary", "micro", "macro", "weighted", "none"]],
     multidim_average: Literal["global", "samplewise"] = "global",
     multilabel: bool = False,
+    ignore_index: Optional[int] = None,
     top_k: int = 1,
     zero_division: float = 0,
 ) -> Tensor:
@@ -56,7 +57,7 @@ def _precision_recall_reduce(
         return _safe_divide(tp, tp + different_stat, zero_division)
 
     score = _safe_divide(tp, tp + different_stat, zero_division)
-    return _adjust_weights_safe_divide(score, average, multilabel, tp, fp, fn, top_k=top_k)
+    return _adjust_weights_safe_divide(score, average, multilabel, tp, fp, fn, ignore_index = ignore_index, top_k=top_k)
 
 
 def binary_precision(

--- a/src/torchmetrics/functional/classification/precision_recall.py
+++ b/src/torchmetrics/functional/classification/precision_recall.py
@@ -57,7 +57,7 @@ def _precision_recall_reduce(
         return _safe_divide(tp, tp + different_stat, zero_division)
 
     score = _safe_divide(tp, tp + different_stat, zero_division)
-    return _adjust_weights_safe_divide(score, average, multilabel, tp, fp, fn, ignore_index = ignore_index, top_k=top_k)
+    return _adjust_weights_safe_divide(score, average, multilabel, tp, fp, fn, ignore_index=ignore_index, top_k=top_k)
 
 
 def binary_precision(

--- a/src/torchmetrics/utilities/compute.py
+++ b/src/torchmetrics/utilities/compute.py
@@ -61,7 +61,7 @@ def _safe_divide(num: Tensor, denom: Tensor, zero_division: float = 0.0) -> Tens
 
 
 def _adjust_weights_safe_divide(
-    score: Tensor, average: Optional[str], multilabel: bool, tp: Tensor, fp: Tensor, fn: Tensor, top_k: int = 1
+    score: Tensor, average: Optional[str], multilabel: bool, tp: Tensor, fp: Tensor, fn: Tensor, ignore_index:Optional[int] = None, top_k: int = 1
 ) -> Tensor:
     if average is None or average == "none":
         return score
@@ -71,6 +71,10 @@ def _adjust_weights_safe_divide(
         weights = torch.ones_like(score)
         if not multilabel:
             weights[tp + fp + fn == 0 if top_k == 1 else tp + fn == 0] = 0.0
+            
+    if ignore_index is not None and 0 <= ignore_index < len(score):
+        weights[ignore_index] = 0.0
+    
     return _safe_divide(weights * score, weights.sum(-1, keepdim=True)).sum(-1)
 
 

--- a/src/torchmetrics/utilities/compute.py
+++ b/src/torchmetrics/utilities/compute.py
@@ -61,7 +61,14 @@ def _safe_divide(num: Tensor, denom: Tensor, zero_division: float = 0.0) -> Tens
 
 
 def _adjust_weights_safe_divide(
-    score: Tensor, average: Optional[str], multilabel: bool, tp: Tensor, fp: Tensor, fn: Tensor, ignore_index:Optional[int] = None, top_k: int = 1
+    score: Tensor,
+    average: Optional[str],
+    multilabel: bool,
+    tp: Tensor,
+    fp: Tensor,
+    fn: Tensor,
+    ignore_index: Optional[int] = None,
+    top_k: int = 1,
 ) -> Tensor:
     if average is None or average == "none":
         return score
@@ -71,10 +78,10 @@ def _adjust_weights_safe_divide(
         weights = torch.ones_like(score)
         if not multilabel:
             weights[tp + fp + fn == 0 if top_k == 1 else tp + fn == 0] = 0.0
-            
+
     if ignore_index is not None and 0 <= ignore_index < len(score):
         weights[ignore_index] = 0.0
-    
+
     return _safe_divide(weights * score, weights.sum(-1, keepdim=True)).sum(-1)
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #2441
<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

## Did you have fun?

Yes

## Issue:
- The root of the problem seems to be that the `ignore_index` information is not being properly propagated to the final averaging step i.e. the  `_adjust_weights_safe_divide` function doesn't know that which class should be ignored.
## Solution:
- To address this issue, I updated the code to ensure that the `ignore_index` information is preserved throughout the entire process, making sure it is correctly passed through all intermediate steps up to the final averaging stage i.e. `_adjust_weights_safe_divide` function .
- Updated the `_adjust_weights_safe_divide` function to accept an additional `ignore_index` parameter, which is passed through the `_precision_recall_reduce` function, called in the `compute` method of the `MulticlassRecall` class. This change adjusts the weights in the function, setting the weight of the ignored class to 0.